### PR TITLE
Fix include guard warning

### DIFF
--- a/Source/TriggerEx.h
+++ b/Source/TriggerEx.h
@@ -19,4 +19,4 @@ class TriggerEx : public Trigger
 	// todo: any other get/set type of functions
 };
 
-#endif _TRIGGEREX_H_
+#endif // _TRIGGEREX_H_


### PR DESCRIPTION
There should be no tokens after `#endif`. Usual practice is to list the opening defined name as a comment at the closing line.