### PR TITLE
Fix include guard `#endif`

### DIFF
--- a/Source/TriggerEx.h
+++ b/Source/TriggerEx.h
@@ -19,4 +19,4 @@ class TriggerEx : public Trigger
 	// todo: any other get/set type of functions
 };
 
-#endif _TRIGGEREX_H_
+#endif // _TRIGGEREX_H_


### PR DESCRIPTION
The `#endif` directive does not take a following token. This was flagged by Mingw:
```
Source/TriggerEx.h:22:8: warning: extra tokens at end of #endif directive [-Wendif-labels]
 #endif _TRIGGEREX_H_
```
