### PR TITLE
Allow getting the turret type of a guard post stored in a conVec

### DIFF
--- a/Source/UnitEx.cpp
+++ b/Source/UnitEx.cpp
@@ -176,7 +176,7 @@ struct OP2Unit
 	unsigned int flags;
 	char bayWeaponCargo[6];
 	char unknown6;
-	char unknownCargo;
+	char conVecCargoTurret; // Turret of a guard post stored in a conVec
 	int unknown7;
 	short timerStickyfoam;
 	short timerEMP;
@@ -958,6 +958,23 @@ void UnitEx::SetLaunchPadCargo(map_id moduleType)
 	}
 
 	(*unitArray)[unitID].launchPadCargo = moduleType;
+}
+
+map_id UnitEx::GetConVecCargoTurret()
+{
+	if (!isInited) {
+		return static_cast<map_id>(HFLNOTINITED);
+	}
+
+	if (!IsLive() || (GetType() != mapConVec)) {
+		return static_cast<map_id>(-1);
+	}
+
+	if (GetCargo() == mapGuardPost) {
+		return static_cast<map_id>((*unitArray)[unitID].conVecCargoTurret);
+	}
+
+	return static_cast<map_id>(-1);
 }
 
 int UnitEx::GetLights()

--- a/Source/UnitEx.cpp
+++ b/Source/UnitEx.cpp
@@ -967,7 +967,7 @@ map_id UnitEx::GetConVecCargoTurret()
 	}
 
 	if (!IsLive() || (GetType() != mapConVec)) {
-		return static_cast<map_id>(-1);
+		return map_id::mapNone;
 	}
 
 	if (GetCargo() == mapGuardPost) {

--- a/Source/UnitEx.h
+++ b/Source/UnitEx.h
@@ -41,6 +41,7 @@ public:
 	map_id GetFactoryCargoWeapon(int bay);
 	map_id GetLaunchPadCargo();
 	void SetLaunchPadCargo(map_id moduleType);
+	map_id GetConVecCargoTurret();
 	int GetLights();
 	int GetDoubleFireRate();
 	int GetInvisible();


### PR DESCRIPTION
Closes #32 

Issues #32 discussed adding a function to set a turret in ConVec. This is already achievable through the function `Unit::SetCargo(mapGuardPost, mapESG)`.