### PR TITLE
Simplify setting waypoint in UnitEx::DoDock

### DIFF
--- a/Source/UnitEx.cpp
+++ b/Source/UnitEx.cpp
@@ -339,12 +339,7 @@ void UnitEx::DoDock(LOCATION dockLocation)
 	data->numUnits = 1;
 	data->unitId = unitID;
 	data->numWayPoints = 1;
-	long wpt = 0,
-		x = dockLocation.x,
-		y = dockLocation.y;
-	wpt |= (x & 0x7ff) << 5;
-	wpt |= (y & 0x3ff) << 20;
-	data->pts.rawPoints = wpt;
+	data->pts.rawPoints = ((dockLocation.x & 0x7ff) << 5) | ((dockLocation.y & 0x3ff) << 20);
 
 	ExtPlayer[OwnerID()].ProcessCommandPacket(&packet);
 }


### PR DESCRIPTION
Closes #27 

One of the solutions mentioned by @DanRStevens was setting the value in a constructor. They following code already exists for a waypoint, could it be updated to take a constructor?

```C++
struct wayPoint // todo: check into this
{
	unsigned :5;
	unsigned int x:15;
	unsigned int y:14;
};

union wayPoints {
	wayPoint points;
	unsigned int rawPoints;
};
```