### PR TITLE
UnitEx general improvements

### DIFF
--- a/Source/UnitEx.cpp
+++ b/Source/UnitEx.cpp
@@ -1137,7 +1137,7 @@ int UnitEx::GetNumTruckLoadsSoFar()
 		return HFLNOTINITED;
 	}
 
-	BeaconData* p = (BeaconData*)((int)(*unitArray) + (unitID*120) + 0x58);
+	BeaconData* p = (BeaconData*)((int)(*unitArray) + (unitID * sizeof(OP2Unit)) + 0x58);
 	return p->numTruckLoadsSoFar;
 }
 
@@ -1147,7 +1147,7 @@ int UnitEx::GetBarYield()
 		return HFLNOTINITED;
 	}
 
-	BeaconData* p = (BeaconData*)((int)(*unitArray) + (unitID * 120) + 0x58);
+	BeaconData* p = (BeaconData*)((int)(*unitArray) + (unitID * sizeof(OP2Unit)) + 0x58);
 	return p->barYield;
 }
 
@@ -1157,7 +1157,7 @@ int UnitEx::GetVariant()
 		return HFLNOTINITED;
 	}
 
-	BeaconData* p = (BeaconData*)((int)(*unitArray) + (unitID * 120) + 0x58);
+	BeaconData* p = (BeaconData*)((int)(*unitArray) + (unitID * sizeof(OP2Unit)) + 0x58);
 	return p->variant;
 }
 
@@ -1167,7 +1167,7 @@ int UnitEx::GetOreType()
 		return HFLNOTINITED;
 	}
 
-	BeaconData* p = (BeaconData*)((int)(*unitArray) + (unitID * 120) + 0x58);
+	BeaconData* p = (BeaconData*)((int)(*unitArray) + (unitID * sizeof(OP2Unit)) + 0x58);
 	return p->oreType;
 }
 
@@ -1177,7 +1177,7 @@ int UnitEx::GetSurveyedBy()
 		return HFLNOTINITED;
 	}
 
-	BeaconData* p = (BeaconData*)((int)(*unitArray) + (unitID * 120) + 0x58);
+	BeaconData* p = (BeaconData*)((int)(*unitArray) + (unitID * sizeof(OP2Unit)) + 0x58);
 	return p->surveyedBy;
 }
 
@@ -1187,7 +1187,7 @@ int UnitEx::GetLabCurrentTopic()
 		return HFLNOTINITED;
 	}
 
-	LabData* p = (LabData*)((int)(*unitArray) + (unitID * 120) + 0x24);
+	LabData* p = (LabData*)((int)(*unitArray) + (unitID * sizeof(OP2Unit)) + 0x24);
 	return p->techNum;
 }
 
@@ -1197,7 +1197,7 @@ int UnitEx::GetLabScientistCount()
 		return HFLNOTINITED;
 	}
 
-	LabData* p = (LabData*)((int)(*unitArray) + (unitID * 120) + 0x24);
+	LabData* p = (LabData*)((int)(*unitArray) + (unitID * sizeof(OP2Unit)) + 0x24);
 	return p->numScientists;
 }
 
@@ -1207,7 +1207,7 @@ void UnitEx::SetLabScientistCount(int numScientists)
 		return;
 	}
 
-	LabData* p = (LabData*)((int)(*unitArray) + (unitID * 120) + 0x24);
+	LabData* p = (LabData*)((int)(*unitArray) + (unitID * sizeof(OP2Unit)) + 0x24);
 	p->numScientists = numScientists;
 }
 

--- a/Source/UnitEx.cpp
+++ b/Source/UnitEx.cpp
@@ -210,6 +210,9 @@ struct BeaconData
 	char surveyedBy; // [player bit vector]
 };
 
+// Offset to LabData pointer within OP2Unit
+constexpr std::uintptr_t labDataOffset = 0x24;
+
 struct LabData
 {
 	short nextResearchTime;		// Amount of time until next research increment(research progresses in chunks)
@@ -1191,7 +1194,7 @@ int UnitEx::GetLabCurrentTopic()
 		return HFLNOTINITED;
 	}
 
-	LabData* p = (LabData*)((int)(*unitArray) + (unitID * sizeof(OP2Unit)) + 0x24);
+	LabData* p = (LabData*)((int)(*unitArray) + (unitID * sizeof(OP2Unit)) + labDataOffset);
 	return p->techNum;
 }
 
@@ -1201,7 +1204,7 @@ int UnitEx::GetLabScientistCount()
 		return HFLNOTINITED;
 	}
 
-	LabData* p = (LabData*)((int)(*unitArray) + (unitID * sizeof(OP2Unit)) + 0x24);
+	LabData* p = (LabData*)((int)(*unitArray) + (unitID * sizeof(OP2Unit)) + labDataOffset);
 	return p->numScientists;
 }
 
@@ -1211,7 +1214,7 @@ void UnitEx::SetLabScientistCount(int numScientists)
 		return;
 	}
 
-	LabData* p = (LabData*)((int)(*unitArray) + (unitID * sizeof(OP2Unit)) + 0x24);
+	LabData* p = (LabData*)((int)(*unitArray) + (unitID * sizeof(OP2Unit)) + labDataOffset);
 	p->numScientists = numScientists;
 }
 

--- a/Source/UnitEx.cpp
+++ b/Source/UnitEx.cpp
@@ -193,6 +193,8 @@ struct OP2Unit
 	short unknown15;
 };
 
+static_assert(120 == sizeof(OP2Unit), "OP2Unit is an unexpected size");
+
 struct BeaconData
 {
 	int numTruckLoadsSoFar;

--- a/Source/UnitEx.cpp
+++ b/Source/UnitEx.cpp
@@ -1144,7 +1144,7 @@ int UnitEx::GetNumTruckLoadsSoFar()
 		return HFLNOTINITED;
 	}
 
-	BeaconData* p = (BeaconData*)((int)(*unitArray) + (unitID * sizeof(OP2Unit)) + beaconDataOffset);
+	BeaconData* p = (BeaconData*)(reinterpret_cast<std::uintptr_t>(*unitArray) + (unitID * sizeof(OP2Unit)) + beaconDataOffset);
 	return p->numTruckLoadsSoFar;
 }
 
@@ -1154,7 +1154,7 @@ int UnitEx::GetBarYield()
 		return HFLNOTINITED;
 	}
 
-	BeaconData* p = (BeaconData*)((int)(*unitArray) + (unitID * sizeof(OP2Unit)) + beaconDataOffset);
+	BeaconData* p = (BeaconData*)(reinterpret_cast<std::uintptr_t>(*unitArray) + (unitID * sizeof(OP2Unit)) + beaconDataOffset);
 	return p->barYield;
 }
 
@@ -1164,7 +1164,7 @@ int UnitEx::GetVariant()
 		return HFLNOTINITED;
 	}
 
-	BeaconData* p = (BeaconData*)((int)(*unitArray) + (unitID * sizeof(OP2Unit)) + beaconDataOffset);
+	BeaconData* p = (BeaconData*)(reinterpret_cast<std::uintptr_t>(*unitArray) + (unitID * sizeof(OP2Unit)) + beaconDataOffset);
 	return p->variant;
 }
 
@@ -1174,7 +1174,7 @@ int UnitEx::GetOreType()
 		return HFLNOTINITED;
 	}
 
-	BeaconData* p = (BeaconData*)((int)(*unitArray) + (unitID * sizeof(OP2Unit)) + beaconDataOffset);
+	BeaconData* p = (BeaconData*)(reinterpret_cast<std::uintptr_t>(*unitArray) + (unitID * sizeof(OP2Unit)) + beaconDataOffset);
 	return p->oreType;
 }
 
@@ -1184,7 +1184,7 @@ int UnitEx::GetSurveyedBy()
 		return HFLNOTINITED;
 	}
 
-	BeaconData* p = (BeaconData*)((int)(*unitArray) + (unitID * sizeof(OP2Unit)) + beaconDataOffset);
+	BeaconData* p = (BeaconData*)(reinterpret_cast<std::uintptr_t>(*unitArray) + (unitID * sizeof(OP2Unit)) + beaconDataOffset);
 	return p->surveyedBy;
 }
 
@@ -1194,7 +1194,7 @@ int UnitEx::GetLabCurrentTopic()
 		return HFLNOTINITED;
 	}
 
-	LabData* p = (LabData*)((int)(*unitArray) + (unitID * sizeof(OP2Unit)) + labDataOffset);
+	LabData* p = (LabData*)(reinterpret_cast<std::uintptr_t>(*unitArray) + (unitID * sizeof(OP2Unit)) + labDataOffset);
 	return p->techNum;
 }
 
@@ -1204,7 +1204,7 @@ int UnitEx::GetLabScientistCount()
 		return HFLNOTINITED;
 	}
 
-	LabData* p = (LabData*)((int)(*unitArray) + (unitID * sizeof(OP2Unit)) + labDataOffset);
+	LabData* p = (LabData*)(reinterpret_cast<std::uintptr_t>(*unitArray) + (unitID * sizeof(OP2Unit)) + labDataOffset);
 	return p->numScientists;
 }
 
@@ -1214,6 +1214,6 @@ void UnitEx::SetLabScientistCount(int numScientists)
 		return;
 	}
 
-	LabData* p = (LabData*)((int)(*unitArray) + (unitID * sizeof(OP2Unit)) + labDataOffset);
+	LabData* p = (LabData*)(reinterpret_cast<std::uintptr_t>(*unitArray) + (unitID * sizeof(OP2Unit)) + labDataOffset);
 	p->numScientists = numScientists;
 }

--- a/Source/UnitEx.cpp
+++ b/Source/UnitEx.cpp
@@ -1,4 +1,5 @@
 #include "HFL.h"
+#include <cstdint>
 
 #pragma pack(push,1)
 // All of these structs have room for only one unit ID as the functions operate on one unit only.
@@ -194,6 +195,9 @@ struct OP2Unit
 };
 
 static_assert(120 == sizeof(OP2Unit), "OP2Unit is an unexpected size");
+
+// Offset to BeaconData pointer within OP2Unit
+constexpr std::uintptr_t beaconDataOffset = 0x58;
 
 struct BeaconData
 {
@@ -1137,7 +1141,7 @@ int UnitEx::GetNumTruckLoadsSoFar()
 		return HFLNOTINITED;
 	}
 
-	BeaconData* p = (BeaconData*)((int)(*unitArray) + (unitID * sizeof(OP2Unit)) + 0x58);
+	BeaconData* p = (BeaconData*)((int)(*unitArray) + (unitID * sizeof(OP2Unit)) + beaconDataOffset);
 	return p->numTruckLoadsSoFar;
 }
 
@@ -1147,7 +1151,7 @@ int UnitEx::GetBarYield()
 		return HFLNOTINITED;
 	}
 
-	BeaconData* p = (BeaconData*)((int)(*unitArray) + (unitID * sizeof(OP2Unit)) + 0x58);
+	BeaconData* p = (BeaconData*)((int)(*unitArray) + (unitID * sizeof(OP2Unit)) + beaconDataOffset);
 	return p->barYield;
 }
 
@@ -1157,7 +1161,7 @@ int UnitEx::GetVariant()
 		return HFLNOTINITED;
 	}
 
-	BeaconData* p = (BeaconData*)((int)(*unitArray) + (unitID * sizeof(OP2Unit)) + 0x58);
+	BeaconData* p = (BeaconData*)((int)(*unitArray) + (unitID * sizeof(OP2Unit)) + beaconDataOffset);
 	return p->variant;
 }
 
@@ -1167,7 +1171,7 @@ int UnitEx::GetOreType()
 		return HFLNOTINITED;
 	}
 
-	BeaconData* p = (BeaconData*)((int)(*unitArray) + (unitID * sizeof(OP2Unit)) + 0x58);
+	BeaconData* p = (BeaconData*)((int)(*unitArray) + (unitID * sizeof(OP2Unit)) + beaconDataOffset);
 	return p->oreType;
 }
 
@@ -1177,7 +1181,7 @@ int UnitEx::GetSurveyedBy()
 		return HFLNOTINITED;
 	}
 
-	BeaconData* p = (BeaconData*)((int)(*unitArray) + (unitID * sizeof(OP2Unit)) + 0x58);
+	BeaconData* p = (BeaconData*)((int)(*unitArray) + (unitID * sizeof(OP2Unit)) + beaconDataOffset);
 	return p->surveyedBy;
 }
 

--- a/Source/UnitEx.cpp
+++ b/Source/UnitEx.cpp
@@ -1138,14 +1138,19 @@ void UnitEx::SetAnimation(int animIdx, int animDelay, int animStartDelay, int bo
 	func(&(*unitArray)[unitID], 0, animIdx, animDelay, animStartDelay, boolInvisible, boolSkipDoDeath);
 }
 
+// HFL initialization must be checked before calling GetBeaconData
+BeaconData& GetBeaconData(int unitID)
+{
+	return *(BeaconData*)(reinterpret_cast<std::uintptr_t>(*unitArray) + (unitID * sizeof(OP2Unit)) + beaconDataOffset);
+}
+
 int UnitEx::GetNumTruckLoadsSoFar()
 {
 	if (!isInited) {
 		return HFLNOTINITED;
 	}
 
-	BeaconData* p = (BeaconData*)(reinterpret_cast<std::uintptr_t>(*unitArray) + (unitID * sizeof(OP2Unit)) + beaconDataOffset);
-	return p->numTruckLoadsSoFar;
+	return GetBeaconData(unitID).numTruckLoadsSoFar;
 }
 
 int UnitEx::GetBarYield()
@@ -1154,8 +1159,7 @@ int UnitEx::GetBarYield()
 		return HFLNOTINITED;
 	}
 
-	BeaconData* p = (BeaconData*)(reinterpret_cast<std::uintptr_t>(*unitArray) + (unitID * sizeof(OP2Unit)) + beaconDataOffset);
-	return p->barYield;
+	return GetBeaconData(unitID).barYield;
 }
 
 int UnitEx::GetVariant()
@@ -1164,8 +1168,7 @@ int UnitEx::GetVariant()
 		return HFLNOTINITED;
 	}
 
-	BeaconData* p = (BeaconData*)(reinterpret_cast<std::uintptr_t>(*unitArray) + (unitID * sizeof(OP2Unit)) + beaconDataOffset);
-	return p->variant;
+	return GetBeaconData(unitID).variant;
 }
 
 int UnitEx::GetOreType()
@@ -1174,8 +1177,7 @@ int UnitEx::GetOreType()
 		return HFLNOTINITED;
 	}
 
-	BeaconData* p = (BeaconData*)(reinterpret_cast<std::uintptr_t>(*unitArray) + (unitID * sizeof(OP2Unit)) + beaconDataOffset);
-	return p->oreType;
+	return GetBeaconData(unitID).oreType;
 }
 
 int UnitEx::GetSurveyedBy()
@@ -1184,8 +1186,7 @@ int UnitEx::GetSurveyedBy()
 		return HFLNOTINITED;
 	}
 
-	BeaconData* p = (BeaconData*)(reinterpret_cast<std::uintptr_t>(*unitArray) + (unitID * sizeof(OP2Unit)) + beaconDataOffset);
-	return p->surveyedBy;
+	return GetBeaconData(unitID).surveyedBy;
 }
 
 // HFL initialization must be checked before calling GetLabData

--- a/Source/UnitEx.cpp
+++ b/Source/UnitEx.cpp
@@ -1217,4 +1217,3 @@ void UnitEx::SetLabScientistCount(int numScientists)
 	LabData* p = (LabData*)((int)(*unitArray) + (unitID * sizeof(OP2Unit)) + labDataOffset);
 	p->numScientists = numScientists;
 }
-

--- a/Source/UnitEx.cpp
+++ b/Source/UnitEx.cpp
@@ -1141,7 +1141,8 @@ void UnitEx::SetAnimation(int animIdx, int animDelay, int animStartDelay, int bo
 // HFL initialization must be checked before calling GetBeaconData
 BeaconData& GetBeaconData(int unitID)
 {
-	return *(BeaconData*)(reinterpret_cast<std::uintptr_t>(*unitArray) + (unitID * sizeof(OP2Unit)) + beaconDataOffset);
+	return *reinterpret_cast<BeaconData*>(
+		reinterpret_cast<std::uintptr_t>(*unitArray) + (unitID * sizeof(OP2Unit)) + beaconDataOffset);
 }
 
 int UnitEx::GetNumTruckLoadsSoFar()
@@ -1192,7 +1193,8 @@ int UnitEx::GetSurveyedBy()
 // HFL initialization must be checked before calling GetLabData
 LabData& GetLabData(int unitID) 
 {
-	return *(LabData*)(reinterpret_cast<std::uintptr_t>(*unitArray) + (unitID * sizeof(OP2Unit)) + labDataOffset);
+	return *reinterpret_cast<LabData*>(
+		reinterpret_cast<std::uintptr_t>(*unitArray) + (unitID * sizeof(OP2Unit)) + labDataOffset);
 }
 
 int UnitEx::GetLabCurrentTopic()

--- a/Source/UnitEx.cpp
+++ b/Source/UnitEx.cpp
@@ -1188,14 +1188,19 @@ int UnitEx::GetSurveyedBy()
 	return p->surveyedBy;
 }
 
+// HFL initialization must be checked before calling GetLabData
+LabData& GetLabData(int unitID) 
+{
+	return *(LabData*)(reinterpret_cast<std::uintptr_t>(*unitArray) + (unitID * sizeof(OP2Unit)) + labDataOffset);
+}
+
 int UnitEx::GetLabCurrentTopic()
 {
 	if (!isInited) {
 		return HFLNOTINITED;
 	}
 
-	LabData* p = (LabData*)(reinterpret_cast<std::uintptr_t>(*unitArray) + (unitID * sizeof(OP2Unit)) + labDataOffset);
-	return p->techNum;
+	return GetLabData(unitID).techNum;
 }
 
 int UnitEx::GetLabScientistCount()
@@ -1204,8 +1209,7 @@ int UnitEx::GetLabScientistCount()
 		return HFLNOTINITED;
 	}
 
-	LabData* p = (LabData*)(reinterpret_cast<std::uintptr_t>(*unitArray) + (unitID * sizeof(OP2Unit)) + labDataOffset);
-	return p->numScientists;
+	return GetLabData(unitID).numScientists;
 }
 
 void UnitEx::SetLabScientistCount(int numScientists)
@@ -1214,6 +1218,5 @@ void UnitEx::SetLabScientistCount(int numScientists)
 		return;
 	}
 
-	LabData* p = (LabData*)(reinterpret_cast<std::uintptr_t>(*unitArray) + (unitID * sizeof(OP2Unit)) + labDataOffset);
-	p->numScientists = numScientists;
+	GetLabData(unitID).numScientists = numScientists;
 }


### PR DESCRIPTION
Should close #28 

I think long term we should somehow include the LabData and BeaconData pointers within the OP2Unit structure. I'm not sure how to accomplish this since they overlap other objects. I'm assuming a union or maybe a class inheritance could accomplish? Maybe we can open an issue to discuss best solution.